### PR TITLE
Avoid tracking HuggingFace token even from the wrong place

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 __pycache__/
 
 # HuggingFace API token
-/.hf_token
+.hf_token
 
 # Jupyter notebook checkpoints
 .ipynb_checkpoints/


### PR DESCRIPTION
If an .hf-token file is in a subdirectory, it won't be found to use, but at least it will still be ignored and less likely to be accidentally committed.